### PR TITLE
Add batched Dependabot updates and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:30"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.17.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:ci
+
+      - name: Build
+        run: npm run build --if-present


### PR DESCRIPTION
## What changed

- added weekly grouped Dependabot updates for npm minor and patch dependencies
- added weekly grouped Dependabot updates for GitHub Actions
- added CI for pushes to `main` and pull requests
- configured CI to install with `npm ci`, run the existing Jest CI suite, then run a build when a build script exists
- matched the repository's declared Node.js version of 20.17.0

## Why

This consolidates routine dependency maintenance into fewer pull requests and makes test validation automatic before any build step.

## Validation

The repository already defines `test:ci` as `jest --ci --reporters=jest-junit`, so the workflow runs that command directly. There is currently no build script, therefore the final step uses `npm run build --if-present`; tests remain mandatory while the workflow is ready for a future build script.